### PR TITLE
Converted the registration system to invite-only.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'bcrypt', '~> 3.1.7'
 
 # Mailboxer, handle messaging between users
-gem 'mailboxer', '~> 0.12.5'
+gem 'mailboxer', github: 'div/mailboxer', branch: 'rails42-foreigner'
 gem 'kaminari'
 
 # Rails frontend specific gems:
@@ -57,6 +57,7 @@ gem 'foreman', '~> 0.75'
 gem 'bootstrap-sass', '~> 3.3.1'
 gem 'autoprefixer-rails'
 gem 'devise', '~> 3.4.1'
+gem 'devise_invitable', '~> 1.4.0'
 gem 'pundit', '~> 0.3.0'
 gem 'use_case', '~> 1.0.2'
 gem 'reform', '~> 1.2.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: git://github.com/div/mailboxer.git
+  revision: 41c9d8de2e0ad4dc511718074228d40a1ba96ebe
+  branch: rails42-foreigner
+  specs:
+    mailboxer (0.12.4)
+      carrierwave (>= 0.5.8)
+      rails (>= 3.2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -90,6 +99,9 @@ GEM
       responders
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
+    devise_invitable (1.4.0)
+      actionmailer (>= 3.2.6, < 5)
+      devise (>= 3.2.0)
     diff-lcs (1.2.5)
     disposable (0.0.9)
       representable (~> 2.0)
@@ -107,8 +119,6 @@ GEM
       railties (>= 3.0.0)
     faker (1.4.3)
       i18n (~> 0.5)
-    foreigner (1.7.2)
-      activerecord (>= 3.0.0)
     foreman (0.77.0)
       dotenv (~> 1.0.2)
       thor (~> 0.19.1)
@@ -144,10 +154,6 @@ GEM
       mime-types (>= 1.16, < 3)
     mail_safe (0.3.4)
       actionmailer (>= 3.0.0)
-    mailboxer (0.12.5)
-      carrierwave (>= 0.5.8)
-      foreigner (>= 0.9.1)
-      rails (>= 3.2.0)
     method_source (0.8.2)
     mime-types (2.4.3)
     mini_portile (0.6.2)
@@ -297,6 +303,7 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   database_cleaner
   devise (~> 3.4.1)
+  devise_invitable (~> 1.4.0)
   dotenv-rails
   factory_girl_rails
   faker
@@ -305,7 +312,7 @@ DEPENDENCIES
   jquery-rails
   kaminari
   mail_safe
-  mailboxer (~> 0.12.5)
+  mailboxer!
   pg
   pry-rails
   puma

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,4 +6,15 @@ class ApplicationController < ActionController::Base
 
   after_action :verify_authorized, :except => :index, unless: -> { is_a? DeviseController }
   after_action :verify_policy_scoped, :only => :index, unless: -> { is_a? DeviseController }
+
+
+  protected
+  
+  # Devise invitable gem uses this method to determine whether someone can
+  # send invitations. Here we're just having it redirect to pundit, so that
+  # all our authorization is in one place.
+  def authenticate_inviter!
+    authenticate_user!
+    raise Pundit::NotAuthorizedError unless Pundit.policy!(current_user, :invitation).send?
+  end
 end

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -1,4 +1,5 @@
 class CommunitiesController < ApplicationController
+  before_filter :authenticate_user!
   before_action :set_community, only: [:show, :edit, :update, :destroy]
 
   respond_to :html

--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -1,4 +1,5 @@
 class OffersController < ApplicationController
+  before_filter :authenticate_user!
   before_action :set_offer, only: [:show, :edit, :update, :destroy]
   skip_after_action :verify_authorized, only: [:index, :search]
 

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,4 +1,5 @@
 class ProfilesController < ApplicationController
+  before_filter :authenticate_user!
   before_action :set_profile, only: [:show, :edit, :update, :destroy]
 
   respond_to :html

--- a/app/models/persistent/user.rb
+++ b/app/models/persistent/user.rb
@@ -1,7 +1,7 @@
 class Persistent::User < Persistent::Base
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, :registerable,
+  devise :invitable, :database_authenticatable, #:registerable, # Commenting registerable to make it invite only.
          :recoverable, :rememberable, :trackable, :validatable, :confirmable
 
   acts_as_messageable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,6 @@ class User < DomainModel
 
   collection :offers, :Offer
   collection :communities, :Community
+
+  delegate :is_admin?, to: :model
 end

--- a/app/policies/invitation_policy.rb
+++ b/app/policies/invitation_policy.rb
@@ -1,0 +1,5 @@
+class InvitationPolicy < Struct.new(:user, :invitation)
+  def send?
+    user.is_admin?
+  end
+end

--- a/app/policies/invitation_policy.rb
+++ b/app/policies/invitation_policy.rb
@@ -1,5 +1,5 @@
 class InvitationPolicy < Struct.new(:user, :invitation)
   def send?
-    user.is_admin?
+    user.present? && user.is_admin?
   end
 end

--- a/app/views/devise/invitations/edit.html.haml
+++ b/app/views/devise/invitations/edit.html.haml
@@ -1,0 +1,9 @@
+.col-sm-6.col-sm-offset-3.panel.panel-default
+  .panel-body
+    %h2= t 'devise.invitations.edit.header'
+    = simple_form_for resource, :as => resource_name, :url => invitation_path(resource_name), :html => { :method => :put } do |f|
+      = devise_error_messages!
+      = f.hidden_field :invitation_token
+      = f.input :password
+      = f.input :password_confirmation
+      = f.button :submit, t("devise.invitations.edit.submit_button")

--- a/app/views/devise/invitations/new.html.haml
+++ b/app/views/devise/invitations/new.html.haml
@@ -1,0 +1,8 @@
+.col-sm-6.col-sm-offset-3.panel.panel-default
+  .panel-body
+    %h2= t "devise.invitations.new.header"
+    = simple_form_for resource, :as => resource_name, :url => invitation_path(resource_name), :html => {:method => :post} do |f|
+      = devise_error_messages!
+      - resource.class.invite_key_fields.each do |field|
+        = f.input field
+      = f.button :submit, t("devise.invitations.new.submit_button")

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -1,0 +1,7 @@
+<p><%= t("devise.mailer.invitation_instructions.hello", email: @resource.email) %></p>
+
+<p><%= t("devise.mailer.invitation_instructions.someone_invited_you", url: root_url) %></p>
+
+<p><%= link_to t("devise.mailer.invitation_instructions.accept"), accept_invitation_url(@resource, :invitation_token => @token) %></p>
+
+<p><%= t("devise.mailer.invitation_instructions.ignore").html_safe %></p>

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -62,5 +62,7 @@
                 %li= link_to t('nav.people'), profiles_path
                 %li= link_to t('nav.offers'), offers_path
                 %li= link_to t('nav.conversations'), conversations_path
+                - if Pundit.policy(current_user, :invitation).send?
+                  %li= link_to t('nav.invite'), new_user_invitation_path
       %footer
         %p &copy; JoatU 2014

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -40,8 +40,9 @@
             = form_tag(destroy_user_session_path, method: :delete, class: "navbar-form navbar-right") do
               %button.btn.btn-default.btn-sm{type: "submit"}= t('devise.form.log_out')
           - else
-            = form_tag(new_user_registration_path, method: :get, class: "navbar-form navbar-right") do
-              %button.btn.btn-default.btn-sm{type: "submit"}= t('devise.form.sign_up')
+            - if respond_to? :new_user_registration_path # Only include registration link if user registration is enabled!
+              = form_tag(new_user_registration_path, method: :get, class: "navbar-form navbar-right") do
+                %button.btn.btn-default.btn-sm{type: "submit"}= t('devise.form.sign_up')
             = form_tag(new_user_session_path, class: "navbar-form navbar-right") do
               .form-group
                 %input.form-control.input-sm{name: "user[email]", type: "text", placeholder: t('devise.form.email')}

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -99,6 +99,45 @@ Devise.setup do |config|
   # Setup a pepper to generate the encrypted password.
   config.pepper = ENV.fetch("DEVISE_PEPPER")
 
+  # ==> Configuration for :invitable
+  # The period the generated invitation token is valid, after
+  # this period, the invited resource won't be able to accept the invitation.
+  # When invite_for is 0 (the default), the invitation won't expire.
+  # config.invite_for = 2.weeks
+
+  # Number of invitations users can send.
+  # - If invitation_limit is nil, there is no limit for invitations, users can
+  # send unlimited invitations, invitation_limit column is not used.
+  # - If invitation_limit is 0, users can't send invitations by default.
+  # - If invitation_limit n > 0, users can send n invitations.
+  # You can change invitation_limit column for some users so they can send more
+  # or less invitations, even with global invitation_limit = 0
+  # Default: nil
+  # config.invitation_limit = 5
+
+  # The key to be used to check existing users when sending an invitation
+  # and the regexp used to test it when validate_on_invite is not set.
+  # config.invite_key = {:email => /\A[^@]+@[^@]+\z/}
+  # config.invite_key = {:email => /\A[^@]+@[^@]+\z/, :username => nil}
+
+  # Flag that force a record to be valid before being actually invited
+  # Default: false
+  # config.validate_on_invite = true
+
+  # Resend invitation if user with invited status is invited again
+  # Default: true
+  # config.resend_invitation = false
+
+  # The class name of the inviting model. If this is nil,
+  # the #invited_by association is declared to be polymorphic.
+  # Default: nil
+  # config.invited_by_class_name = 'User'
+
+  # The column name used for counter_cache column. If this is nil,
+  # the #invited_by association is declared without counter_cache.
+  # Default: nil
+  # config.invited_by_counter_cache = :invitations_count
+
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without
   # confirming their account. For instance, if set to 2.days, the user will be

--- a/config/locales/devise_invitable.en.yml
+++ b/config/locales/devise_invitable.en.yml
@@ -1,0 +1,23 @@
+en:
+  devise:
+    failure:
+      invited: 'You have a pending invitation, accept it to finish creating your account.'
+    invitations:
+      send_instructions: 'An invitation email has been sent to %{email}.'
+      invitation_token_invalid: 'The invitation token provided is not valid!'
+      updated: 'Your password was set successfully. You are now signed in.'
+      no_invitations_remaining: "No invitations remaining"
+      invitation_removed: 'Your invitation was removed.'
+      new:
+        header: "Send invitation"
+        submit_button: "Send an invitation"
+      edit:
+        header: "Set your password"
+        submit_button: "Set my password"
+    mailer:
+      invitation_instructions:
+        subject: 'Invitation instructions'
+        hello: 'Hello %{email}'
+        someone_invited_you: 'Someone has invited you to %{url}, you can accept it through the link below.'
+        accept: 'Accept invitation'
+        ignore: "If you don't want to accept the invitation, please ignore this email.<br />Your account won't be created until you access the link above and set your password."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,6 +55,7 @@ en:
     side_header: "Navigation"
     offers: "Offers"
     conversations: "Conversations"
+    invite: "Invite New Users"
   messages:
     from: "From"
     subject: "Subject"

--- a/db/migrate/20150127020303_devise_invitable_add_to_users.rb
+++ b/db/migrate/20150127020303_devise_invitable_add_to_users.rb
@@ -1,0 +1,27 @@
+class DeviseInvitableAddToUsers < ActiveRecord::Migration
+  def up
+    change_table :users do |t|
+      t.string     :invitation_token
+      t.datetime   :invitation_created_at
+      t.datetime   :invitation_sent_at
+      t.datetime   :invitation_accepted_at
+      t.integer    :invitation_limit
+      t.references :invited_by, :polymorphic => true
+      t.integer    :invitations_count, default: 0
+      t.index      :invitations_count
+      t.index      :invitation_token, :unique => true # for invitable
+      t.index      :invited_by_id
+    end
+
+    # And allow null encrypted_password and password_salt:
+    change_column_null :users, :encrypted_password, true
+  end
+
+  def down
+    change_table :users do |t|
+      t.remove_references :invited_by, :polymorphic => true
+      t.remove :invitations_count, :invitation_limit, :invitation_sent_at, :invitation_accepted_at, :invitation_token, :invitation_created_at
+    end
+    change_column_null    :users, :encrypted_password, false
+  end
+end

--- a/db/migrate/20150127022304_add_is_admin_to_users.rb
+++ b/db/migrate/20150127022304_add_is_admin_to_users.rb
@@ -1,0 +1,7 @@
+class AddIsAdminToUsers < ActiveRecord::Migration
+  def change
+    change_table :users do |t|
+      t.boolean :is_admin, default: false, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150125025830) do
+ActiveRecord::Schema.define(version: 20150127020303) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -103,7 +103,7 @@ ActiveRecord::Schema.define(version: 20150125025830) do
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
+    t.string   "encrypted_password",     default: ""
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
@@ -118,9 +118,20 @@ ActiveRecord::Schema.define(version: 20150125025830) do
     t.string   "unconfirmed_email"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "invitation_token"
+    t.datetime "invitation_created_at"
+    t.datetime "invitation_sent_at"
+    t.datetime "invitation_accepted_at"
+    t.integer  "invitation_limit"
+    t.integer  "invited_by_id"
+    t.string   "invited_by_type"
+    t.integer  "invitations_count",      default: 0
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
+  add_index "users", ["invitation_token"], name: "index_users_on_invitation_token", unique: true, using: :btree
+  add_index "users", ["invitations_count"], name: "index_users_on_invitations_count", using: :btree
+  add_index "users", ["invited_by_id"], name: "index_users_on_invited_by_id", using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
   add_foreign_key "mailboxer_conversation_opt_outs", "mailboxer_conversations", column: "conversation_id", name: "mb_opt_outs_on_conversations_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150127020303) do
+ActiveRecord::Schema.define(version: 20150127022304) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -102,12 +102,12 @@ ActiveRecord::Schema.define(version: 20150127020303) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                  default: "", null: false
+    t.string   "email",                  default: "",    null: false
     t.string   "encrypted_password",     default: ""
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
+    t.integer  "sign_in_count",          default: 0,     null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.inet     "current_sign_in_ip"
@@ -126,6 +126,7 @@ ActiveRecord::Schema.define(version: 20150127020303) do
     t.integer  "invited_by_id"
     t.string   "invited_by_type"
     t.integer  "invitations_count",      default: 0
+    t.boolean  "is_admin",               default: false, null: false
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree


### PR DESCRIPTION
- New feature: some users can be marked admins in the DB.
- Only admins can invite new users.
- Users cannot self-register (though this can easily be re-enabled).
- Fix #16